### PR TITLE
Add defer to termbox.Close()

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	}()
 
 	<-done
-	termbox.Close()
+	defer termbox.Close()
 	io.Copy(os.Stdout, r)
 }
 


### PR DESCRIPTION
In a tmux window, when play exits, it leaves the terminal in an odd state where newlines aren't registering correctly. Simply adding the defer so that termbox cleanly exits seems to have fixed it for me.